### PR TITLE
Update black to v22.3.0

### DIFF
--- a/tools/requirements-pip.txt
+++ b/tools/requirements-pip.txt
@@ -1,6 +1,6 @@
 autoflake==1.4
 autopep8==1.6.0
-black==21.12b0
+black==22.3.0
 docformatter==1.4
 isort==5.10.1
 pylint==2.12.2


### PR DESCRIPTION
Click 8.1.0 had a breaking change that broke black; updating to 22.3.0 resolves that issue. See https://github.com/psf/black/issues/2964